### PR TITLE
Check that everything works with ptracer and pt-run from /usr/local

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,19 @@ jobs:
                   make
                   sudo make install
 
-            - name: Build
-              run: |
-                  make all && sudo make install
+            - name: Build base Library
+              run: make library && sudo make install
+
+            - name: Build test scripts
+              run: make tests examples CPPFLAGS=''
 
             - name: Install Busted
               run: luarocks --local install busted
 
+            # To test that everthing works with ptracer.h and pt-run from
+            # /usr/local, we compile the tests without the "-I" preprocessor
+            # flag and we don't use "./run-tests". That script adds the current
+            # directory to the PATH, so it would use the local copy of pt-run.
             - name: Run Tests
               run: |
                   eval "$(luarocks path)"

--- a/examples/fibonacci/fibonacci.c
+++ b/examples/fibonacci/fibonacci.c
@@ -6,7 +6,7 @@
  */
 
 #define PT_IMPLEMENTATION
-#include "ptracer.h"
+#include <ptracer.h>
 
 /* User specific macros when Pallene Tracer debug mode is enabled. */
 #ifdef PT_DEBUG

--- a/run-tests
+++ b/run-tests
@@ -6,4 +6,5 @@
 #   ./run-tests
 #   ./run-tests -k
 #   ./run-tests spec/traceback_spec.lua
+export PATH="$(pwd):$PATH"
 make tests && busted --verbose --no-keep-going "$@"

--- a/spec/tracebacks/anon_lua/module.c
+++ b/spec/tracebacks/anon_lua/module.c
@@ -7,7 +7,7 @@
 
 /* Static use of the library would suffice. */
 #define PT_IMPLEMENTATION
-#include "ptracer.h"
+#include <ptracer.h>
 
 /* Here goes user specifc macros when Pallene Tracer debug mode is active. */
 #ifdef PT_DEBUG

--- a/spec/tracebacks/depth_recursion/module.c
+++ b/spec/tracebacks/depth_recursion/module.c
@@ -7,7 +7,7 @@
 
 /* Static use of the library would suffice. */
 #define PT_IMPLEMENTATION
-#include "ptracer.h"
+#include <ptracer.h>
 
 /* Here goes user specific macros when Pallene Tracer debug mode is active. */
 #ifdef PT_DEBUG

--- a/spec/tracebacks/dispatch/module.c
+++ b/spec/tracebacks/dispatch/module.c
@@ -7,7 +7,7 @@
 
 /* Static use of the library would suffice. */
 #define PT_IMPLEMENTATION
-#include "ptracer.h"
+#include <ptracer.h>
 
 /* Here goes user specific macros when Pallene Tracer debug mode is active. */
 #ifdef PT_DEBUG

--- a/spec/tracebacks/ellipsis/module.c
+++ b/spec/tracebacks/ellipsis/module.c
@@ -7,7 +7,7 @@
 
 /* Static use of the library would suffice. */
 #define PT_IMPLEMENTATION
-#include "ptracer.h"
+#include <ptracer.h>
 
 /* Here goes user specific macros when Pallene Tracer debug mode is active. */
 #ifdef PT_DEBUG

--- a/spec/tracebacks/multimod/module_a.c
+++ b/spec/tracebacks/multimod/module_a.c
@@ -6,7 +6,7 @@
  */
 
 #define PT_IMPLEMENTATION
-#include "ptracer.h"
+#include <ptracer.h>
 
 #include "module_include.h"
 

--- a/spec/tracebacks/multimod/module_b.c
+++ b/spec/tracebacks/multimod/module_b.c
@@ -6,7 +6,7 @@
  */
 
 #define PT_IMPLEMENTATION
-#include "ptracer.h"
+#include <ptracer.h>
 
 #include "module_include.h"
 

--- a/spec/tracebacks/singular/module.c
+++ b/spec/tracebacks/singular/module.c
@@ -7,7 +7,7 @@
 
 /* Static use of the library would suffice. */
 #define PT_IMPLEMENTATION
-#include "ptracer.h"
+#include <ptracer.h>
 
 /* Here goes user specific macros when Pallene Tracer debug mode is active. */
 #ifdef PT_DEBUG

--- a/spec/tracebacks_spec.lua
+++ b/spec/tracebacks_spec.lua
@@ -9,9 +9,8 @@ local function assert_test(example, expected_content)
     assert(util.execute("make --quiet tests"))
 
     local cdir  = util.shell_quote("spec/tracebacks/"..example)
-    local ptrun = util.shell_quote("../../../pt-run")
     local ok, _, output_content, err_content =
-        util.outputs_of_execute(string.format("cd %s && %s main.lua", cdir, ptrun))
+        util.outputs_of_execute(string.format("cd %s && pt-run main.lua", cdir))
     assert(not ok, output_content)
     assert.are.same(expected_content, err_content)
 end


### PR DESCRIPTION
Get rid of the "../../pt-run", by adding it to the PATH. The tricky bit is that ./run-tests no longer is a trivial wrapper around busted, because it sets the PATH. Thus, I'm not 100% sold that we actually want to do this. Anyway, I'm leaving this here for feedback.

It's inconvenient to do make install every time we want to run the test suite. So I set it up to run the /usr/local tests only in the Github CI. To test that the compilation works with /usr/local version of ptracer.h, clear the CPPFLAGS variable when compiling the tests.