### PR TITLE
Supply Pallene Tracer Error Handler Function

### DIFF
--- a/pt-lua.c
+++ b/pt-lua.c
@@ -985,6 +985,7 @@ int main (int argc, char **argv) {
   lua_pop(L, 1);  /* We do not need the finalizer object here */
 
   /* supply the message handler function with custom tracebacks. */
+  /* it is safe to set globals at this point, because no code has been run yet. */
   lua_pushcfunction(L, msghandler);
   lua_setglobal(L, "pallene_tracer_errhandler");
   /* -------- PALLENE TRACER CODE END -------- */

--- a/pt-lua.c
+++ b/pt-lua.c
@@ -983,6 +983,10 @@ int main (int argc, char **argv) {
   /* -------- PALLENE TRACER CODE -------- */
   (void) pallene_tracer_init(L);  /* initialize pallene tracer */
   lua_pop(L, 1);  /* We do not need the finalizer object here */
+
+  /* supply the message handler function with custom tracebacks. */
+  lua_pushcfunction(L, msghandler);
+  lua_setglobal(L, "pallene_tracer_errhandler");
   /* -------- PALLENE TRACER CODE END -------- */
 
   lua_pushcfunction(L, &pmain);  /* to call 'pmain' in protected mode */


### PR DESCRIPTION
Changelog: 
 - Supply the error handler function to be used against `xpcall`.