### PR TITLE
Makefile edit to build on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,11 @@ CFLAGS   = -DPT_DEBUG -g -std=c99 -pedantic -Wall -Wextra -Wformat-security
 # Explicitly mention which Lua headers to capture
 CPPFLAGS = -I$(LUA_INCDIR) -I.
 LIBFLAG  = -fPIC -shared
+LDFLAGS = -L$(LUA_LIBDIR)
 
 # The -Wl,-E tells the linker to not throw away unused Lua API symbols.
 # We need them for Lua modules that are dynamically linked via require
-PTLUA_LDFLAGS = -L$(LUA_LIBDIR) -Wl,-E
+PTLUA_LDFLAGS = -Wl,-E
 PTLUA_LDLIBS  = -llua -lm
 
 # ===================
@@ -65,7 +66,7 @@ clean:
 	rm -rf pt-lua examples/*/*.so spec/tracebacks/*/*.so
 
 %.so: %.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(LIBFLAG) $< -o $@
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(LIBFLAG) $< -o $@ $(PTLUA_LDLIBS)
 
 pt-lua: pt-lua.c ptracer.h
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(PTLUA_LDFLAGS) $< -o $@ $(PTLUA_LDLIBS)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ LDFLAGS = -L$(LUA_LIBDIR)
 
 # The -Wl,-E tells the linker to not throw away unused Lua API symbols.
 # We need them for Lua modules that are dynamically linked via require
-PTLUA_LDFLAGS = -Wl,-E
+PTLUA_LDFLAGS = -Wl,-export_dynamic
 PTLUA_LDLIBS  = -llua -lm
 
 # ===================

--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,14 @@ CFLAGS   = -DPT_DEBUG -g -std=c99 -pedantic -Wall -Wextra -Wformat-security
 # Explicitly mention which Lua headers to capture
 CPPFLAGS = -I$(LUA_INCDIR) -I.
 LIBFLAG  = -fPIC -shared
+SO_LDFLAGS = -L$(LUA_LIBDIR)
 
 # The -Wl,-E tells the linker to not throw away unused Lua API symbols.
 # We need them for Lua modules that are dynamically linked via require
 # Note: the xcode (macos) linker uses -export-dynamic instead of -E.
 # To build on macos, use make EXPFLAG=-export-dynamic
 EXPFLAG = -E
-LDFLAGS = -Wl,$(EXPFLAG)
-PTLUA_LDFLAGS = -L$(LUA_LIBDIR)
+PTLUA_LDFLAGS = -L$(LUA_LIBDIR) -Wl,$(EXPFLAG)
 PTLUA_LDLIBS  = -llua -lm
 
 # ===================
@@ -69,7 +69,7 @@ clean:
 	rm -rf pt-lua examples/*/*.so spec/tracebacks/*/*.so
 
 %.so: %.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(PTLUA_LDFLAGS) $(LIBFLAG) $< -o $@ $(PTLUA_LDLIBS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(SO_LDFLAGS) $(LIBFLAG) $< -o $@ $(PTLUA_LDLIBS)
 
 pt-lua: pt-lua.c ptracer.h
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(PTLUA_LDFLAGS) $< -o $@ $(PTLUA_LDLIBS)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ CFLAGS   = -DPT_DEBUG -g -std=c99 -pedantic -Wall -Wextra -Wformat-security
 # Explicitly mention which Lua headers to capture
 CPPFLAGS = -I$(LUA_INCDIR) -I.
 LIBFLAG  = -fPIC -shared
-SO_LDFLAGS = -L$(LUA_LIBDIR)
+SO_LDFLAGS = -L$(LUA_LIBDIR) -llua
 
 # The -Wl,-E tells the linker to not throw away unused Lua API symbols.
 # We need them for Lua modules that are dynamically linked via require
@@ -69,7 +69,7 @@ clean:
 	rm -rf pt-lua examples/*/*.so spec/tracebacks/*/*.so
 
 %.so: %.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(SO_LDFLAGS) $(LIBFLAG) $< -o $@ $(PTLUA_LDLIBS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(SO_LDFLAGS) $(LIBFLAG) $< -o $@
 
 pt-lua: pt-lua.c ptracer.h
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(PTLUA_LDFLAGS) $< -o $@ $(PTLUA_LDLIBS)

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ uninstall:
 
 clean:
 	rm -rf pt-lua examples/*/*.so spec/tracebacks/*/*.so
+	rm -rf pt-lua.dSYM spec/tracebacks/*/*.dSYM examples/*/*.dSYM
 
 %.so: %.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(SO_LDFLAGS) $(LIBFLAG) $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ LIBFLAG  = -fPIC -shared
 
 # The -Wl,-E tells the linker to not throw away unused Lua API symbols.
 # We need them for Lua modules that are dynamically linked via require
-PTLUA_LDFLAGS = -L$(LUA_LIBDIR) -Wl,-export_dynamic
+PTLUA_LDFLAGS = -Wl,--export_dynamic
 PTLUA_LDLIBS  = -llua -lm
 
 # ===================
@@ -68,7 +68,7 @@ clean:
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -L$(LUA_LIBDIR) $(LIBFLAG) $< -o $@ $(PTLUA_LDLIBS)
 
 pt-lua: pt-lua.c ptracer.h
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(PTLUA_LDFLAGS) $< -o $@ $(PTLUA_LDLIBS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -L$(LUA_LIBDIR) $(PTLUA_LDFLAGS) $< -o $@ $(PTLUA_LDLIBS)
 
 examples/fibonacci/fibonacci.so:           examples/fibonacci/fibonacci.c           ptracer.h
 spec/tracebacks/anon_lua/module.so:        spec/tracebacks/anon_lua/module.c        ptracer.h

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,10 @@ CFLAGS   = -DPT_DEBUG -g -std=c99 -pedantic -Wall -Wextra -Wformat-security
 # Explicitly mention which Lua headers to capture
 CPPFLAGS = -I$(LUA_INCDIR) -I.
 LIBFLAG  = -fPIC -shared
-LDFLAGS = -L$(LUA_LIBDIR)
 
 # The -Wl,-E tells the linker to not throw away unused Lua API symbols.
 # We need them for Lua modules that are dynamically linked via require
-PTLUA_LDFLAGS = -Wl,-export_dynamic
+PTLUA_LDFLAGS = -L$(LUA_LIBDIR) -Wl,-export_dynamic
 PTLUA_LDLIBS  = -llua -lm
 
 # ===================
@@ -66,7 +65,7 @@ clean:
 	rm -rf pt-lua examples/*/*.so spec/tracebacks/*/*.so
 
 %.so: %.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(LIBFLAG) $< -o $@ $(PTLUA_LDLIBS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -L$(LUA_LIBDIR) $(LIBFLAG) $< -o $@ $(PTLUA_LDLIBS)
 
 pt-lua: pt-lua.c ptracer.h
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(PTLUA_LDFLAGS) $< -o $@ $(PTLUA_LDLIBS)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,11 @@ LIBFLAG  = -fPIC -shared
 
 # The -Wl,-E tells the linker to not throw away unused Lua API symbols.
 # We need them for Lua modules that are dynamically linked via require
-PTLUA_LDFLAGS = -Wl,--export_dynamic
+# Note: the xcode (macos) linker uses -export-dynamic instead of -E.
+# To build on macos, use make EXPFLAG=-export-dynamic
+EXPFLAG = -E
+LDFLAGS = -Wl,$(EXPFLAG)
+PTLUA_LDFLAGS = -L$(LUA_LIBDIR)
 PTLUA_LDLIBS  = -llua -lm
 
 # ===================
@@ -65,10 +69,10 @@ clean:
 	rm -rf pt-lua examples/*/*.so spec/tracebacks/*/*.so
 
 %.so: %.c
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -L$(LUA_LIBDIR) $(LIBFLAG) $< -o $@ $(PTLUA_LDLIBS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(PTLUA_LDFLAGS) $(LIBFLAG) $< -o $@ $(PTLUA_LDLIBS)
 
 pt-lua: pt-lua.c ptracer.h
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -L$(LUA_LIBDIR) $(PTLUA_LDFLAGS) $< -o $@ $(PTLUA_LDLIBS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(PTLUA_LDFLAGS) $< -o $@ $(PTLUA_LDLIBS)
 
 examples/fibonacci/fibonacci.so:           examples/fibonacci/fibonacci.c           ptracer.h
 spec/tracebacks/anon_lua/module.so:        spec/tracebacks/anon_lua/module.c        ptracer.h

--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ sudo make install
 
 Pallene Tracer supplies a custom Lua frontend `pt-lua` and `ptracer.h` header (including source).
 
+### Runnning tests
+
+If your lua prefix is `/usr`, simply run:
+```
+./run-tests
+```
+
+If you are using a local lua prefix (not `/usr`), you will need to build the tests separately before running the test script:
+```
+make LUA_PREFIX=<preferred_prefix> tests
+./run-tests
+```
+
 ### How to use Pallene Tracer
 
 The developers manual on how Pallene Tracer works and used can be found in [docs](https://github.com/pallene-lang/pallene-tracer/blob/main/docs/MANUAL.md). Also feel free to look at the `examples` directory for further intuition.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ make LUA_PREFIX=/usr/local
 
 > **Note:** Default `LUA_PREFIX` is `/usr`.
 
+The linker supplied with Apple's Xcode command line developer tools does not use the same flag conventions as the GNU linker, gold, LLVM lld, etc. **On macos**, you may have to manually specify the `-export_dynamic` linker flag:
+
+```
+make PTLUA_LDFLAGS=-Wl,-export_dynamic LUA_PREFIX=<preferred_prefix>
+```
+
 Pallene Tracer sometime fails to build if Lua is built with address sanitizer (ASan) enabled. To get around the issue use: 
 ```
 make LDFLAGS=-lasan LUA_PREFIX=<preferred_prefix>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ make LUA_PREFIX=/usr/local
 The linker supplied with Apple's Xcode command line developer tools does not use the same flag conventions as the GNU linker, gold, LLVM lld, etc. **On macos**, you may have to manually specify the `-export_dynamic` linker flag:
 
 ```
-make PTLUA_LDFLAGS=-Wl,-export_dynamic LUA_PREFIX=<preferred_prefix>
+make EXPFLAG=-export_dynamic LUA_PREFIX=<preferred_prefix>
 ```
 
 Pallene Tracer sometime fails to build if Lua is built with address sanitizer (ASan) enabled. To get around the issue use: 


### PR DESCRIPTION
NOT READY FOR MERGE. Disclaimer: I'm not at all a Makefile or C toolchain expert.

These are changes I had to make to be able to puild pt_lua and run tests on macos.

The second commit (`-export_dynamic`) you should not taken as-is. It is to illustrate what I needed to do for Apple ld, but I guess it will break GNU ld which uses `-E` or `--export_dynamic`. Can the right flag be detected/selected conditionally without dragging in all of autotools?