### PR TITLE
Include llimits.h (fix)

### DIFF
--- a/pt-lua.c
+++ b/pt-lua.c
@@ -56,6 +56,7 @@
 #include <signal.h>
 
 #include "lua.h"
+#include "llimits.h"
 
 #include "lauxlib.h"
 #include "lualib.h"


### PR DESCRIPTION
Possibly an workaround for "lua-internals" 5.5.0