### PR TITLE
Uninstall 'pt-lua' instead of 'pt-run'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ install: library
 
 uninstall:
 	rm -rf $(INCDIR)/ptracer.h
-	rm -rf $(BINDIR)/pt-run
+	rm -rf $(BINDIR)/pt-lua
 
 clean:
 	rm -rf pt-lua examples/*/*.so spec/tracebacks/*/*.so


### PR DESCRIPTION
Bug: The file `pt-lua` wasn't being uninstalled due to a typo in the `uninstall` step.